### PR TITLE
Global gitignore file

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,0 +1,3 @@
+sftp-config.json
+*.sublime-workspace
+*.sublime-project

--- a/setup.sh
+++ b/setup.sh
@@ -14,9 +14,11 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-for file in .{aliases,bash_profile,bashrc,functions,git-completion,profile,vimrc}; do
+for file in .{aliases,bash_profile,bashrc,functions,git-completion,gitignore_global,profile,vimrc}; do
   rm -f $HOME/$file
   ln -s $DIR/$file $HOME/$file
 done
+
+git config --global core.excludesfile $HOME/.gitignore_global
 
 echo "Symlinks created!"


### PR DESCRIPTION
These changes add a global gitignore file to the home directory and set it up with git config. Right now, the only files included in the global gitignore are the sftp_config.json (used by the SFTP package in Sublime) and Sublime-specific workspace files.